### PR TITLE
Update to remove 3.8.0 deprecation of asyncio.Task.all_tasks()

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@
 [![PyPI version](https://badge.fury.io/py/asynccmd.svg)](https://badge.fury.io/py/asynccmd)
 [![PyPI](https://img.shields.io/pypi/status/asynccmd.svg)](https://img.shields.io/pypi/status/asynccmd.svg)
 
-# WHY THIS FORK?
-
-I want to use this package with Python 3.8, and there is at least one issue, a deprication warning for the use of Task.all_tasks()
-
 
 # asynccmd
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 [![PyPI version](https://badge.fury.io/py/asynccmd.svg)](https://badge.fury.io/py/asynccmd)
 [![PyPI](https://img.shields.io/pypi/status/asynccmd.svg)](https://img.shields.io/pypi/status/asynccmd.svg)
 
+# WHY THIS FORK?
+
+I want to use this package with Python 3.8, and there is at least one issue, a deprication warning for the use of Task.all_tasks()
+
 
 # asynccmd
 

--- a/asynccmd/asynccmd.py
+++ b/asynccmd/asynccmd.py
@@ -92,8 +92,11 @@ class Cmd:
             except KeyboardInterrupt:
                 print("Cmd._start_controller stop loop. Bye.")
                 self.loop.stop()
-                pending = asyncio.Task.all_tasks(loop=self.loop)
-                print(asyncio.Task.all_tasks(loop=self.loop))
+                if sys.version_info >= (3, 8, 0):
+                    pending = asyncio.all_tasks(loop=self.loop)
+                else:
+                    pending = asyncio.Task.all_tasks(loop=self.loop)
+                print(pending)
                 for task in pending:
                     task.cancel()
                     with suppress(asyncio.CancelledError):

--- a/examples/aiohttp_example.py
+++ b/examples/aiohttp_example.py
@@ -101,7 +101,11 @@ class Commander(Cmd):
             self.aiohttp_servers = aiohttp_servers
 
     def do_tasks(self, arg):
-        for task in asyncio.Task.all_tasks(loop=self.loop):
+        if sys.version_info >= (3, 8, 0):
+            pending = asyncio.all_tasks(loop=self.loop)
+        else:
+            pending = asyncio.Task.all_tasks(loop=self.loop)
+        for task in pending:
             print(task)
 
     def start(self, loop=None):
@@ -125,7 +129,10 @@ except KeyboardInterrupt:
     pass
 finally:
     loop.stop()
-    pending = asyncio.Task.all_tasks(loop=loop)
+    if sys.version_info >= (3, 8, 0):
+        pending = asyncio.all_tasks(loop=self.loop)
+    else:
+        pending = asyncio.Task.all_tasks(loop=self.loop)
     for task in pending:
         task.cancel()
         with suppress(asyncio.CancelledError):

--- a/examples/main.py
+++ b/examples/main.py
@@ -37,7 +37,11 @@ class Commander(Cmd):
         :param arg: contain args that go after command
         :return: None
         """
-        for task in asyncio.Task.all_tasks(loop=self.loop):
+        if sys.version_info >= (3, 8, 0):
+            pending = asyncio.all_tasks(loop=self.loop)
+        else:
+            pending = asyncio.Task.all_tasks(loop=self.loop)
+        for task in pending:
             print(task)
 
     def start(self, loop=None):

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -17,7 +17,11 @@ class SimpleCommander(Cmd):
         :param arg: contain args that go after command
         :return: None
         """
-        for task in asyncio.Task.all_tasks(loop=self.loop):
+        if sys.version_info >= (3, 8, 0):
+            pending = asyncio.all_tasks(loop=self.loop)
+        else:
+            pending = asyncio.Task.all_tasks(loop=self.loop)
+        for task in pending:
             print(task)
 
     def start(self, loop=None):


### PR DESCRIPTION
There are a few uses of asyncio.Task.all_tasks(). Only one in actual library, in an exception handler. The rest are in examples. These all trigger deprecation warning in Python 3.8.0. I used a simple way to remove them by testing the version of python and using the newer asyncio.all_tasks() instead.

I don't know when the call was deprecated, perhaps it was prior to 3.8.0, so maybe the code should be modified to use an earlier version.

Alternatively, it could be done by trying to call asyncio.all_tasks() inside a try block and calling Task.all_tasks in the exception branch. That seemed like enough of a style sensitive decision that the original author should decide.

